### PR TITLE
Fix r->0 limit in BS solver

### DIFF
--- a/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
+++ b/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
@@ -627,9 +627,11 @@ double BosonStarSolver::DA_RHS(const double x, const double A, const double DA,
                                const double OM, const double ww_)
 {
     double r = ((x == 0.) ? eps : x);
+    double origin_fac = ((x == 0.) ? (1. / 3.) : 1.); //accounts for limit r->0
+
     double DOM = OMEGA_RHS(x, A, DA, PSI, DPSI, OM, ww_);
-    return A * PSI * PSI * (DV(A) - ww_ / (OM * OM)) -
-           DA * (DOM / OM + DPSI / PSI + 2. / r);
+    return origin_fac * (A * PSI * PSI * (DV(A) - ww_ / (OM * OM)) -
+           DA * (DOM / OM + DPSI / PSI + 2. / r));
 }
 
 // RHS for the conformal factor
@@ -648,10 +650,11 @@ double BosonStarSolver::DPSI_RHS(const double x, const double A,
                                  const double ww_)
 {
     double r = ((x == 0.) ? eps : x);
-    return 0.5 * DPSI * DPSI / PSI - 2. * DPSI / r -
+    double origin_fac = ((x == 0.) ? (1. / 3.) : 1.); //accounts for limit r->0
+    return origin_fac * (0.5 * DPSI * DPSI / PSI - 2. * DPSI / r -
            2. * M_PI * PSI *
                (PSI * PSI * V(A) + DA * DA +
-                ww_ * A * A * PSI * PSI / (OM * OM));
+                ww_ * A * A * PSI * PSI / (OM * OM)));
 }
 
 // RHS for the lapse

--- a/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
+++ b/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
@@ -627,7 +627,7 @@ double BosonStarSolver::DA_RHS(const double x, const double A, const double DA,
                                const double OM, const double ww_)
 {
     double r = ((x == 0.) ? eps : x);
-    double origin_fac = ((x == 0.) ? (1. / 3.) : 1.); //accounts for limit r->0
+    double origin_fac = ((x < eps) ? (1. / 3.) : 1.); //accounts for limit r->0
 
     double DOM = OMEGA_RHS(x, A, DA, PSI, DPSI, OM, ww_);
     return origin_fac * (A * PSI * PSI * (DV(A) - ww_ / (OM * OM)) -
@@ -650,7 +650,7 @@ double BosonStarSolver::DPSI_RHS(const double x, const double A,
                                  const double ww_)
 {
     double r = ((x == 0.) ? eps : x);
-    double origin_fac = ((x == 0.) ? (1. / 3.) : 1.); //accounts for limit r->0
+    double origin_fac = ((x < eps) ? (1. / 3.) : 1.); //accounts for limit r->0
     return origin_fac * (0.5 * DPSI * DPSI / PSI - 2. * DPSI / r -
            2. * M_PI * PSI *
                (PSI * PSI * V(A) + DA * DA +

--- a/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
+++ b/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
@@ -661,7 +661,7 @@ double BosonStarSolver::DPSI_RHS(const double x, const double A,
     //expansion at r = 0 for use at innermost gridpoint
     if (x < eps)
     {
-        return (2. * M_PI * PSI *
+        return (-2. * M_PI * PSI *
                (PSI * PSI * V(A) +
                 ww_ * A * A * PSI * PSI / (OM * OM))) / 3.;
                

--- a/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
+++ b/Source/InitialConditions/BosonStars/BosonStarSolver.impl.hpp
@@ -627,11 +627,19 @@ double BosonStarSolver::DA_RHS(const double x, const double A, const double DA,
                                const double OM, const double ww_)
 {
     double r = ((x == 0.) ? eps : x);
-    double origin_fac = ((x < eps) ? (1. / 3.) : 1.); //accounts for limit r->0
-
     double DOM = OMEGA_RHS(x, A, DA, PSI, DPSI, OM, ww_);
-    return origin_fac * (A * PSI * PSI * (DV(A) - ww_ / (OM * OM)) -
-           DA * (DOM / OM + DPSI / PSI + 2. / r));
+    //expansion at r = 0 for use at innermost gridpoint
+    if (x < eps)
+    {
+        return A * PSI * PSI * (DV(A) - ww_ / (OM * OM)) / 3.;
+    }
+    
+    //ordinary RHS returned everywhere else
+    else 
+    {
+        return A * PSI * PSI * (DV(A) - ww_ / (OM * OM)) -
+               DA * (DOM / OM + DPSI / PSI + 2. / r);
+    }
 }
 
 // RHS for the conformal factor
@@ -648,13 +656,24 @@ double BosonStarSolver::DPSI_RHS(const double x, const double A,
                                  const double DA, const double PSI,
                                  const double DPSI, const double OM,
                                  const double ww_)
-{
+{   
     double r = ((x == 0.) ? eps : x);
-    double origin_fac = ((x < eps) ? (1. / 3.) : 1.); //accounts for limit r->0
-    return origin_fac * (0.5 * DPSI * DPSI / PSI - 2. * DPSI / r -
-           2. * M_PI * PSI *
+    //expansion at r = 0 for use at innermost gridpoint
+    if (x < eps)
+    {
+        return (2. * M_PI * PSI *
+               (PSI * PSI * V(A) +
+                ww_ * A * A * PSI * PSI / (OM * OM))) / 3.;
+               
+    }
+    //ordinary RHS returned everywhere else
+    else
+    {
+        return 0.5 * DPSI * DPSI / PSI - 2. * DPSI / r -
+               2. * M_PI * PSI *
                (PSI * PSI * V(A) + DA * DA +
-                ww_ * A * A * PSI * PSI / (OM * OM)));
+                ww_ * A * A * PSI * PSI / (OM * OM));
+    }
 }
 
 // RHS for the lapse


### PR DESCRIPTION
Fixes the boson star solver to behave correctly in r->0, accounting for terms of the form e.g. DA / r which reduce to D^2A in the limit r -> 0, introducing overall factors of 1/3 in the equations for DA and DPSI at r = 0. This should remove nonconvergent constraint norm spikes that otherwise appear right at the BS center.